### PR TITLE
Potential fix for code scanning alert no. 7: Database query built from user-controlled sources

### DIFF
--- a/dicasParaDevs/modules/express.js
+++ b/dicasParaDevs/modules/express.js
@@ -58,7 +58,15 @@ app.post("/users", async (req, res) => {
 app.patch("/users/:id", async (req, res) => {
   try {
     const id = req.params.id;
-    const user = await UserModel.findByIdAndUpdate(id, req.body, { new: true });
+    // Only allow specific fields to be updated
+    const allowedFields = ["name", "email", "password"]; // adjust as needed
+    const updates = {};
+    for (const field of allowedFields) {
+      if (req.body.hasOwnProperty(field)) {
+        updates[field] = req.body[field];
+      }
+    }
+    const user = await UserModel.findByIdAndUpdate(id, updates, { new: true });
     res.status(200).json(user);
   } catch (error) {
     res.status(500).send(error.message);


### PR DESCRIPTION
Potential fix for [https://github.com/cabraldasilvac/myProject/security/code-scanning/7](https://github.com/cabraldasilvac/myProject/security/code-scanning/7)

To fix this problem, we need to ensure that user input cannot inject arbitrary MongoDB update operators or otherwise manipulate the update query in an unsafe way. The best way to do this is to only allow updates to specific, whitelisted fields, and to construct the update object explicitly from those fields, rather than passing `req.body` directly. This can be done by extracting only the allowed fields from `req.body` and building a new object to use in the update operation. This change should be made in the PATCH `/users/:id` route handler, specifically on line 61. No new imports are needed, but you may need to define an array of allowed fields and a function to filter `req.body` accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
